### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root=true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.java]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[.md]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
fix issue #7 

Create style standard for most IDE's

Some IDE's may need a plugin [link](http://editorconfig.org/#download)
You can also use these CLI programs to fix style faults [link](http://editorconfig.org/#create-a-plugin)

http://editorconfig.org/